### PR TITLE
assocrules: improve performance a bit

### DIFF
--- a/pymining/assocrules.py
+++ b/pymining/assocrules.py
@@ -1,7 +1,6 @@
 def mine_assoc_rules(isets, min_support=2, min_confidence=0.5):
     rules = []
-    visited = set()
-    for key in sorted(isets, key=lambda k: len(k), reverse=True):
+    for key in sorted(isets, key=len, reverse=True):
         support = isets[key]
         if support < min_support or len(key) < 2:
             continue
@@ -10,19 +9,17 @@ def mine_assoc_rules(isets, min_support=2, min_confidence=0.5):
             left = key.difference([item])
             right = frozenset([item])
             _mine_assoc_rules(
-                left, right, support, visited, isets,
+                left, right, item, support, isets,
                 min_support, min_confidence, rules)
 
     return rules
 
 
 def _mine_assoc_rules(
-        left, right, rule_support, visited, isets, min_support,
+        left, right, last_item, rule_support, isets, min_support,
         min_confidence, rules):
-    if (left, right) in visited or len(left) < 1:
+    if not left:
         return
-    else:
-        visited.add((left, right))
 
     support_a = isets[left]
     confidence = float(rule_support) / float(support_a)
@@ -30,8 +27,10 @@ def _mine_assoc_rules(
         rules.append((left, right, rule_support, confidence))
         # We can try to increase right!
         for item in left:
+            if item > last_item: continue
             new_left = left.difference([item])
             new_right = right.union([item])
             _mine_assoc_rules(
-                new_left, new_right, rule_support, visited, isets,
+                new_left, new_right, item, rule_support, isets,
                 min_support, min_confidence, rules)
+


### PR DESCRIPTION
Don't keep track of visited rules → observe increased performance by half.

I wouldn't care to prove it at the moment, but please confirm experimentally that below change produces the exact same set of rules (albeit potentially in a bit different order).
